### PR TITLE
Override Gnosis-chain explorer with gnosisscan

### DIFF
--- a/components/common/util.ts
+++ b/components/common/util.ts
@@ -117,6 +117,7 @@ export function getChainExplorerUrl(chainId: number): string | undefined {
     [ChainId.SyscoinTanenbaumTestnet]: 'https://tanenbaum.io',
     [ChainId.SyscoinMainnet]: 'https://explorer.syscoin.org',
     [ChainId.Astar]: 'https://blockscout.com/astar',
+    [ChainId.Gnosis]: 'https://gnosisscan.io',
   };
 
   const [explorer] = chains.get(chainId)?.explorers ?? [];


### PR DESCRIPTION
Replace Blockscout with Etherscan alike explorer for Gnosis chain (former xdai)