### PR TITLE
Added Stargate Finance Router for Polygon

### DIFF
--- a/public/dapp-contract-list/1/0xBcD7254A1D759EFA08eC7c3291B2E85c5dCC12ce
+++ b/public/dapp-contract-list/1/0xBcD7254A1D759EFA08eC7c3291B2E85c5dCC12ce
@@ -1,0 +1,4 @@
+{
+    "appName": "LooksRare",
+    "label": "LooksRare: Fee Sharing"
+}

--- a/public/dapp-contract-list/137/0x45A01E4e04F14f7A4a6702c74187c5F6222033cd
+++ b/public/dapp-contract-list/137/0x45A01E4e04F14f7A4a6702c74187c5F6222033cd
@@ -1,0 +1,4 @@
+{
+    "appName": "Stargate Finance",
+    "label": "Stargate Finance: Router"
+}


### PR DESCRIPTION
Added Label for Stargate Finance Router on Polygon.

Proof: https://polygonscan.com/address/0x45A01E4e04F14f7A4a6702c74187c5F6222033cd

(App: https://stargate.finance/)
