### PR TITLE
Added contract-address for OpenSea ERC20-proxy-contract (for WETH approval)

### DIFF
--- a/public/dapp-contract-list/137/0x411B0bcf1b6Ea88CB7229558c89994a2449c302c
+++ b/public/dapp-contract-list/137/0x411B0bcf1b6Ea88CB7229558c89994a2449c302c
@@ -1,0 +1,4 @@
+{
+    "appName": "OpenSea",
+    "label": "OpenSea: erc20-proxy-contract for WETH-approval"
+}


### PR DESCRIPTION
Added Contract-address which is being used from Polygon for WETH-based payments on listings and purchases.

A list of these addresses from OpenSea can be found here: https://gist.github.com/rahuldamodar94/6bdd022f3457934f2a104fd5f4bb45e4

A google search validates the address: https://www.google.com/search?q=0x411b0bcf1b6ea88cb7229558c89994a2449c302c

I had also an approval from this contract on a wallet that I had only used for OpenSea with WETH payment.

