### PR TITLE
Add OpenSea Conduit contract labels for more chains

### DIFF
--- a/public/dapp-contract-list/10/0x1E0049783F008A0085193E00003D00cd54003c71.json
+++ b/public/dapp-contract-list/10/0x1E0049783F008A0085193E00003D00cd54003c71.json
@@ -1,0 +1,4 @@
+{
+  "appName": "OpenSea",
+  "label": "OpenSea: Conduit"
+}

--- a/public/dapp-contract-list/137/0x1E0049783F008A0085193E00003D00cd54003c71.json
+++ b/public/dapp-contract-list/137/0x1E0049783F008A0085193E00003D00cd54003c71.json
@@ -1,0 +1,4 @@
+{
+  "appName": "OpenSea",
+  "label": "OpenSea: Conduit"
+}

--- a/public/dapp-contract-list/42161/0x1E0049783F008A0085193E00003D00cd54003c71.json
+++ b/public/dapp-contract-list/42161/0x1E0049783F008A0085193E00003D00cd54003c71.json
@@ -1,0 +1,4 @@
+{
+  "appName": "OpenSea",
+  "label": "OpenSea: Conduit"
+}

--- a/public/dapp-contract-list/43114/0x1E0049783F008A0085193E00003D00cd54003c71.json
+++ b/public/dapp-contract-list/43114/0x1E0049783F008A0085193E00003D00cd54003c71.json
@@ -1,0 +1,4 @@
+{
+  "appName": "OpenSea",
+  "label": "OpenSea: Conduit"
+}

--- a/public/dapp-contract-list/56/0x1E0049783F008A0085193E00003D00cd54003c71.json
+++ b/public/dapp-contract-list/56/0x1E0049783F008A0085193E00003D00cd54003c71.json
@@ -1,0 +1,4 @@
+{
+  "appName": "OpenSea",
+  "label": "OpenSea: Conduit"
+}


### PR DESCRIPTION
Duplicate [public/dapp-contract-list/1/0x1E0049783F008A0085193E00003D00cd54003c71.json](https://github.com/RevokeCash/revoke.cash/blob/master/public/dapp-contract-list/1/0x1E0049783F008A0085193E00003D00cd54003c71.json) for mainnet BSC, Polygon, Arbitrum One, Optimism, and Avalanche.