### PR TITLE
feat: add custom spender filters support

### DIFF
--- a/components/allowances/table/columns.tsx
+++ b/components/allowances/table/columns.tsx
@@ -74,6 +74,18 @@ export const customFilterFns = {
 
     return results.some((result) => result);
   },
+  spender: (row: Row<AllowanceData>, columnId: string, filterValues: string[]) => {
+    const filterSpenders = filterValues
+      .map((_) => _.split(','))
+      .reduce((all, item) => {
+        return all.concat(item);
+      }, [])
+      .map((c) => c.toLowerCase());
+
+    if (!row.original.spender && filterSpenders.length) return false;
+    const spender = row.original.spender.toLowerCase();
+    return filterSpenders.includes(spender);
+  },
   allowance: (row: Row<AllowanceData>, columnId: string, filterValues: string[]) => {
     const results = filterValues.map((filterValue) => {
       if (filterValue === 'Unlimited') return row.getValue(columnId) === 'Unlimited';
@@ -126,6 +138,8 @@ export const columns = [
     header: () => <HeaderCell i18nKey="address:headers.spender" />,
     cell: (info) => <SpenderCell allowance={info.row.original} />,
     enableSorting: false,
+    enableColumnFilter: true,
+    filterFn: customFilterFns.spender,
   }),
   columnHelper.accessor('lastUpdated', {
     id: ColumnId.LAST_UPDATED,

--- a/locales/en/address.json
+++ b/locales/en/address.json
@@ -28,6 +28,9 @@
         "token": "Token"
       }
     },
+    "spender": {
+      "label": "Authorized Spender"
+    },
     "label": "Filters",
     "showing_everything": "Showing Everything"
   },

--- a/locales/zh/address.json
+++ b/locales/zh/address.json
@@ -28,6 +28,9 @@
         "token": "代币"
       }
     },
+    "spender": {
+      "label": "已经授权的项目"
+    },
     "label": "筛选",
     "showing_everything": "显示一切"
   },


### PR DESCRIPTION
accept custom spender filters to highlight specific spenders 

## demo
<img width="1283" alt="image" src="https://user-images.githubusercontent.com/7993835/230915247-1362fab6-3ffa-406b-aaaf-7e0ee5811594.png">


## sample
````json
{"spender":{"name":"Sushi exploited","values":["0x044b75f554b886a065b9567891e45c79542d7357","0xD75F5369724b513b497101fb15211160c1d96550","0x3e603C14aF37EBdaD31709C4f848Fc6aD5BEc715"]}}
````
https://revoke-cash-git-fork-scamsniffer-master-lahana.vercel.app/address/0x57fc2006b44d9618cc675494dce94fac548eb7b4#{%22spender%22:{%22name%22:%22Sushi%20exploited%22,%22values%22:[%220x044b75f554b886a065b9567891e45c79542d7357%22,%220xD75F5369724b513b497101fb15211160c1d96550%22,%220x3e603C14aF37EBdaD31709C4f848Fc6aD5BEc715%22]}}
