### PR TITLE
feat: update "lastUpdated" and "hash" after user updates approval amount

### DIFF
--- a/lib/hooks/ethereum/useAllowances.tsx
+++ b/lib/hooks/ethereum/useAllowances.tsx
@@ -55,8 +55,10 @@ export const useAllowances = (address: Address, events: AddressEvents, chainId: 
     });
   };
 
-  // TODO: Update last updated time
-  const onUpdate = async (allowance: AllowanceData, newAmount?: bigint) => {
+  const onUpdate = async (
+    allowance: AllowanceData,
+    updatedProperties: Pick<AllowanceData, 'amount' | 'transactionHash' | 'lastUpdated'> = {},
+  ) => {
     // Invalidate blockNumber query, which triggers a refetch of the events, which in turn triggers a refetch of the allowances
     // We do not immediately refetch the allowances here, but we want to make sure that allowances will be refetched when
     // users navigate to the allowances page again
@@ -70,7 +72,7 @@ export const useAllowances = (address: Address, events: AddressEvents, chainId: 
       refetchType: 'none',
     });
 
-    if (!newAmount || newAmount === 0n) {
+    if (!updatedProperties.amount || updatedProperties.amount === 0n) {
       return onRevoke(allowance);
     }
 
@@ -78,7 +80,7 @@ export const useAllowances = (address: Address, events: AddressEvents, chainId: 
       return previousAllowances.map((other) => {
         if (!allowanceEquals(other, allowance)) return other;
 
-        const newAllowance = { ...other, amount: newAmount };
+        const newAllowance = { ...other, ...updatedProperties };
         return newAllowance;
       });
     });

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -1,5 +1,6 @@
 import { ERC20_ABI, ERC721_ABI } from 'lib/abis';
 import { Abi, Address, Hash, Hex, PublicClient, WalletClient } from 'viem';
+import type { useAllowances } from './hooks/ethereum/useAllowances';
 
 export type Balance = bigint | 'ERC1155';
 
@@ -167,7 +168,7 @@ export interface TokenMetadata {
   price?: number;
 }
 
-export type OnUpdate = (allowance: AllowanceData, newAmount?: bigint) => void;
+export type OnUpdate = ReturnType<typeof useAllowances>['onUpdate'];
 
 export interface EtherscanPlatform {
   domain: string;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -147,9 +147,14 @@ export const writeContractUnlessExcessiveGas = async <
   return walletClient.writeContract({ ...transactionRequest, gas: estimatedGas } as any);
 };
 
-export const waitForTransactionConfirmation = async (hash: Hash, publicClient: PublicClient): Promise<void> => {
+// TODO: Remove type assertion after migrating to viem v2 (waitForTransactionHash will be properly typed)
+export const waitForTransactionConfirmation = async (
+  hash: Hash,
+  publicClient: PublicClient,
+): Promise<{ blockNumber: bigint }> => {
   try {
-    return void (await publicClient.waitForTransactionReceipt({ hash }));
+    const transactionReceipt = (await publicClient.waitForTransactionReceipt({ hash })) as { blockNumber: bigint };
+    return transactionReceipt;
   } catch (e) {
     // Workaround for Safe Apps, somehow they don't return the transaction receipt -- TODO: remove when fixed
     if (e instanceof TransactionNotFoundError || e instanceof TransactionReceiptNotFoundError) return;


### PR DESCRIPTION
Resolves #167

This change ensures the last updated date and hash of an allowance is updated in the UI after a user updates the approval amount for an ERC20 contract.

Summary of changes:
- `useAllowances`: `onUpdate` now accepts an `updatedProperties` param instead of `newAmount`
- `waitForTransactionConfirmation`: now returns a transaction receipt
- `useRevoke`: when a user updates an ERC20 allowance, we fetch the confirmed block timestamp, then pass the `hash` and `lastUpdated` values to `onUpdate`

Small enhancements:
- Consolidated `OnUpdate` type definition in `lib/interfaces.ts`
- Removed the default value for the `onUpdate` param in the `useRevoke` hook (all `useRevoke` invocations pass an `onUpdate` argument, so figured the default value wasn't necessary)

|Video|
|-|
|<video src="https://github.com/RevokeCash/revoke.cash/assets/12480362/69b7db92-3f3a-4248-8255-a51c352d83dd">|