### PR TITLE
Fix typos and untranslated text in Russian locale files

### DIFF
--- a/locales/ru/address.json
+++ b/locales/ru/address.json
@@ -56,7 +56,7 @@
     "value_at_risk": "Значение риска"
   },
   "labels": {
-    "connected": "Поключено",
+    "connected": "Подключено",
     "nft": "NFT",
     "not_connected": "Не подключено",
     "token": "Токен"

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -12,7 +12,7 @@
     "check": "Проверить",
     "check_connected_address": "Проверьте подключенный адрес",
     "clear_filters": "Очистить фильтры",
-    "close": "Close",
+    "close": "Закрыть",
     "connect": "Подключить кошелек",
     "connecting": "Подключение…",
     "disconnect": "Отключить",


### PR DESCRIPTION
**Description:**  
This update addresses two issues in the Russian locale files:  
1. In `locales/ru/address.json`, corrected the typo "Поключено" to the correct "Подключено" in the `"labels"` section.  
2. In `locales/ru/common.json`, translated the `"Close"` button to Russian, now displayed as `"Закрыть"`.  

These changes improve the localization quality, ensuring a more accurate and user-friendly interface for Russian-speaking users. Fixing such errors is crucial for maintaining a professional product experience and avoiding potential confusion.