### PR TITLE
chore: remove cover images from all pages

### DIFF
--- a/app/[locale]/acknowledgements/page.tsx
+++ b/app/[locale]/acknowledgements/page.tsx
@@ -1,7 +1,7 @@
 import ContentPageLayout from 'app/layouts/ContentPageLayout';
 import MarkdownProse from 'components/common/MarkdownProse';
 import { readAndParseContentFile } from 'lib/utils/markdown-content';
-import type { NextPage } from 'next';
+import type { Metadata, NextPage } from 'next';
 import { setRequestLocale } from 'next-intl/server';
 
 interface Props {
@@ -14,7 +14,7 @@ interface Params {
 
 export const dynamic = 'error';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Acknowledgements',
   description: 'Revoke.cash depends on several third-party tools and services. This page lists them.',
 };

--- a/app/[locale]/blog/[...slug]/layout.tsx
+++ b/app/[locale]/blog/[...slug]/layout.tsx
@@ -51,10 +51,6 @@ const BlogLayout = async ({ params, children }: Props) => {
           <Breadcrumb pages={breadcrumbs} />
           <TranslateButton language={meta.language} translationUrl={translationUrl} />
         </div>
-        <Prose className="mb-4">
-          {meta.coverImage ? <Image src={meta.coverImage} alt={meta.title} width={1200} height={630} /> : null}
-        </Prose>
-        <ArticleMeta meta={meta} />
         {children}
         <Divider className="my-6" />
         <PageNavigation currentPath={`/blog/${slug.join('/')}`} pages={[...posts].reverse()} />

--- a/app/[locale]/blog/[...slug]/page.tsx
+++ b/app/[locale]/blog/[...slug]/page.tsx
@@ -39,9 +39,9 @@ const BlogPostPage: NextPage<Props> = async ({ params }) => {
   const { locale, slug } = await params;
   setRequestLocale(locale);
 
-  const { content } = readAndParseContentFile(slug, locale, 'blog')!;
+  const { content, meta } = readAndParseContentFile(slug, locale, 'blog')!;
 
-  return <MarkdownProse content={content} />;
+  return <MarkdownProse content={content} meta={meta} />;
 };
 
 export default BlogPostPage;

--- a/app/[locale]/learn/[...slug]/page.tsx
+++ b/app/[locale]/learn/[...slug]/page.tsx
@@ -53,7 +53,7 @@ const LearnDocumentPage: NextPage<Props> = async ({ params }) => {
         )}
       </div>
       <LearnLayout sidebarEntries={sidebar} slug={slug} meta={meta} translationUrl={translationUrl}>
-        <MarkdownProse content={content} />
+        <MarkdownProse meta={meta} content={content} />
       </LearnLayout>
     </>
   );

--- a/app/[locale]/og.jpg/blog/[...slug]/route.tsx
+++ b/app/[locale]/og.jpg/blog/[...slug]/route.tsx
@@ -15,7 +15,7 @@ interface Params {
   slug: string[];
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/[locale]/og.jpg/blog/route.tsx
+++ b/app/[locale]/og.jpg/blog/route.tsx
@@ -13,7 +13,7 @@ interface Params {
   locale: string;
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/[locale]/og.jpg/exploits/[slug]/route.tsx
+++ b/app/[locale]/og.jpg/exploits/[slug]/route.tsx
@@ -14,7 +14,7 @@ interface Params {
   slug: string;
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = async () => {

--- a/app/[locale]/og.jpg/exploits/route.tsx
+++ b/app/[locale]/og.jpg/exploits/route.tsx
@@ -13,7 +13,7 @@ interface Params {
   locale: string;
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/[locale]/og.jpg/learn/[...slug]/route.tsx
+++ b/app/[locale]/og.jpg/learn/[...slug]/route.tsx
@@ -15,7 +15,7 @@ interface Params {
   slug: string[];
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/[locale]/og.jpg/learn/[category]/route.tsx
+++ b/app/[locale]/og.jpg/learn/[category]/route.tsx
@@ -15,7 +15,7 @@ interface Params {
   category: string;
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/[locale]/og.jpg/learn/faq/route.tsx
+++ b/app/[locale]/og.jpg/learn/faq/route.tsx
@@ -13,7 +13,7 @@ interface Params {
   locale: string;
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/[locale]/og.jpg/learn/route.tsx
+++ b/app/[locale]/og.jpg/learn/route.tsx
@@ -13,7 +13,7 @@ interface Params {
   locale: string;
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/[locale]/og.jpg/learn/wallets/add-network/[slug]/route.tsx
+++ b/app/[locale]/og.jpg/learn/wallets/add-network/[slug]/route.tsx
@@ -15,7 +15,7 @@ interface Params {
   slug: string;
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/[locale]/og.jpg/learn/wallets/add-network/route.tsx
+++ b/app/[locale]/og.jpg/learn/wallets/add-network/route.tsx
@@ -13,7 +13,7 @@ interface Params {
   locale: string;
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/[locale]/og.jpg/token-approval-checker/[slug]/route.tsx
+++ b/app/[locale]/og.jpg/token-approval-checker/[slug]/route.tsx
@@ -15,7 +15,7 @@ interface Params {
   slug: string;
 }
 
-export const dynamic = 'error';
+export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 
 export const generateStaticParams = () => {

--- a/app/layouts/LearnLayout.tsx
+++ b/app/layouts/LearnLayout.tsx
@@ -47,11 +47,6 @@ const LearnLayout = ({ children, searchBar, sidebarEntries, slug, meta, translat
                 <TranslateButton language={meta.language} translationUrl={translationUrl} />
               </NextIntlClientProvider>
             </div>
-            <Prose className="mb-4">
-              {meta.coverImage ? (
-                <Image src={meta.coverImage} alt={meta.title} width={1200} height={630} priority fetchPriority="high" />
-              ) : null}
-            </Prose>
             {children}
             <Divider className="my-6" />
             <PageNavigation currentPath={`/learn/${slug.join('/')}`} pages={sidebarEntries} />

--- a/components/common/MarkdownProse.tsx
+++ b/components/common/MarkdownProse.tsx
@@ -1,3 +1,5 @@
+import ArticleMeta from 'components/learn/ArticleMeta';
+import type { ContentMeta } from 'lib/interfaces';
 import Image from 'next/image';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -15,15 +17,17 @@ SyntaxHighlighter.registerLanguage('javascript', javascript);
 
 interface Props {
   content: string;
+  meta?: ContentMeta;
   className?: string;
 }
 
-const MarkdownProse = ({ content, className }: Props) => {
+const MarkdownProse = ({ content, meta, className }: Props) => {
   const components: Components & Record<string, any> = {
     h1: ({ children }) => {
       return (
         <>
           <h1>{children}</h1>
+          {meta ? <ArticleMeta meta={meta} /> : null}
           <Divider className="my-4" />
         </>
       );

--- a/components/learn/ArticleCard.tsx
+++ b/components/learn/ArticleCard.tsx
@@ -1,30 +1,15 @@
 import Card from 'components/common/Card';
 import Href from 'components/common/Href';
-import ImageWithFallback from 'components/common/ImageWithFallback';
 import type { ISidebarEntry } from 'lib/interfaces';
 import { useTranslations } from 'next-intl';
 
-const ArticleCard = ({ title, description, path, date, readingTime, coverImage, author }: ISidebarEntry) => {
+const ArticleCard = ({ title, description, path, date, readingTime, author }: ISidebarEntry) => {
   const t = useTranslations();
 
   return (
     <Href href={path} router underline="none">
-      <Card
-        hover="scale"
-        className="flex flex-col justify-between gap-4"
-        image={
-          <ImageWithFallback
-            src={coverImage ?? '/opengraph-image.jpg'}
-            alt={`${title} Cover Image`}
-            width={1200}
-            height={630}
-            className="rounded-t-[calc(var(--radius-lg)-1px)]"
-            fallbackSrc="/opengraph-image.jpg"
-          />
-        }
-      >
+      <Card title={title} hover="scale" className="flex flex-col justify-between gap-4">
         <div className="flex flex-col gap-2">
-          <h2 className="text-xl leading-none">{title}</h2>
           <p>{description}</p>
         </div>
         {date && readingTime ? (

--- a/components/learn/ArticleMeta.tsx
+++ b/components/learn/ArticleMeta.tsx
@@ -21,7 +21,7 @@ const ArticleMeta = ({ meta }: Props) => {
   if (!properties.includes('translator') && !properties.includes('author')) return null;
 
   return (
-    <div className="flex justify-center gap-2 flex-wrap max-sm:text-sm text-center my-4 text-zinc-500 dark:text-zinc-400">
+    <div className="flex justify-start gap-2 flex-wrap max-sm:text-sm text-center my-4 text-zinc-500 dark:text-zinc-400">
       {properties.map((property, i) => (
         <MetaProperty key={property} property={property} meta={meta} separator={i < properties.length - 1} />
       ))}

--- a/content/en/blog/2025/dependency-spotlight-envio.md
+++ b/content/en/blog/2025/dependency-spotlight-envio.md
@@ -10,6 +10,8 @@ translator: <Your Name Here (or remove)>
 
 We are building Revoke.cash on the shoulders of giants. Without the services and tools that we depend on, we would not be able to build the service that we have today. In this series of blog posts, we will be highlighting some of the services and tools that we depend on, and how they help us build Revoke.cash.
 
+::img{src="/assets/images/blog/2025/dependency-spotlight-envio/cover.jpg" alt="Envio" width="1200" height="630"}
+
 To build a service like Revoke.cash, we need to process a lot of data because we look at users' entire transaction histories to determine the current state of their token approvals. This is a lot of data to process, and it's a lot of data to store. We use several services to help us with this, and Envio is one of the most important ones.
 
 ## What is Envio?

--- a/lib/utils/og.tsx
+++ b/lib/utils/og.tsx
@@ -24,18 +24,6 @@ export const generateOgImage = ({ title, background }: OgImageProps) => {
   const width = 1200;
   const height = 630;
 
-  // If SKIP_OG_IMAGES is true, return a placeholder image instead of generating one dynamically.
-  // This significantly speeds up builds during emergency patches by skipping resource-intensive OG image generation.
-  const SKIP_OG_IMAGES = process.env.SKIP_OG_IMAGES === 'true';
-  if (SKIP_OG_IMAGES) {
-    return new Response(Uint8Array.from(loadFile('public/assets/images/opengraph-image.jpg')), {
-      headers: {
-        'Content-Type': 'image/jpeg',
-        'Cache-Control': 'public, max-age=31536000, immutable',
-      },
-    });
-  }
-
   const icon = loadDataUrl('public/assets/images/revoke-icon-orange-black.png', 'image/png');
 
   const response = (


### PR DESCRIPTION
Most of the cover images didn't really add to the articles any way. This makes it easier to create new articles (without needing to generate cover images) and greatly improves build times.