### PR TITLE
fix: switch chain only if it's required

### DIFF
--- a/lib/hooks/ethereum/ensureWalletClient.tsx
+++ b/lib/hooks/ethereum/ensureWalletClient.tsx
@@ -2,6 +2,7 @@
 
 import { useAsyncCallback } from 'react-async-hook';
 import type { WalletClient } from 'viem';
+import { useConnection } from 'wagmi';
 import { getWalletClient } from 'wagmi/actions';
 import { wagmiConfig } from './EthereumProvider';
 import { useSwitchChain } from './useSwitchChain';
@@ -9,11 +10,15 @@ import { useSwitchChain } from './useSwitchChain';
 // Ensures the connected wallet is on target chain, then returns a fresh WalletClient for that chain
 export const useEnsureWalletClient = () => {
   const { switchChainAsync } = useSwitchChain();
+  const { chainId: currentChainId } = useConnection();
 
   const { execute: ensureWalletClient, loading: isLoading } = useAsyncCallback(
     async (chainId: number): Promise<WalletClient> => {
-      // Attempt to switch chain first (wallets that can't switch will throw and be handled by existing toasts)
-      await switchChainAsync(chainId);
+      // Only attempt chain switch when not already on the target chain. Wallets like Safe don't support
+      // programmatic chain switching and would throw if attempting it when already on the right chain.
+      if (currentChainId !== chainId) {
+        await switchChainAsync(chainId);
+      }
 
       const client = await getWalletClient(wagmiConfig, { chainId });
       if (!client) throw new Error('Please connect your web3 wallet to a supported network');

--- a/lib/stores/transaction-store.ts
+++ b/lib/stores/transaction-store.ts
@@ -3,6 +3,7 @@ import type { TransactionStatus, TransactionSubmitted, TransactionType } from 'l
 import {
   isAccountUpgradeRejectionError,
   isBatchSizeError,
+  isSwitchChainNotSupportedError,
   isUserRejectionError,
   parseErrorMessage,
 } from 'lib/utils/errors';
@@ -92,7 +93,7 @@ export const wrapTransaction = ({
       return transactionSubmitted;
     } catch (error) {
       const message = parseErrorMessage(error);
-      if (isUserRejectionError(message)) {
+      if (isUserRejectionError(message) || isSwitchChainNotSupportedError(error)) {
         updateTransaction(transactionKey, { status: 'not_started' });
       } else if (isBatchSizeError(message) || isAccountUpgradeRejectionError(message)) {
         updateTransaction(transactionKey, { status: 'retrying' });

--- a/lib/utils/errors.ts
+++ b/lib/utils/errors.ts
@@ -143,6 +143,18 @@ export const isNetworkError = (error?: string | any): boolean => {
   return false;
 };
 
+export const isSwitchChainNotSupportedError = (error?: string | any): boolean => {
+  if (!error) return false;
+
+  if (typeof error !== 'string') {
+    return (
+      isSwitchChainNotSupportedError(parseErrorMessage(error)) || isSwitchChainNotSupportedError(stringifyError(error))
+    );
+  }
+
+  return error?.toLowerCase()?.includes('does not support programmatic chain switching');
+};
+
 export const isCovalentError = (error?: string | any): boolean => {
   if (!error) return false;
 


### PR DESCRIPTION
When Revoke.cash  triggers a "revoke" action within the iframe:

1. The wagmi useSwitchChain() hook sends a wallet_switchEthereumChain request.
2. The Safe Apps SDK routes this as a Methods.rpcCall.
3. The request is sent to the raw JsonRpcProvider, which rejects it.
4. Wagmi interprets this rejection as a lack of support for the feature and throws a SwitchChainNotSupportedError.

<img width="1512" height="839" alt="Screenshot 2026-06-11 at 19 29 10" src="https://github.com/user-attachments/assets/3838d99c-c5a7-48cd-82e7-ad78a0377cc1" />

Since Safe wallet doesn't support programmatic chain switching through the SDK path the fix is:

1. Verify the Network: Compare the current chainId with the target chainId and skip the switch request if they already match.
2. Graceful Error Handling: Catch the isSwitchChainNotSupportedError. If the connector does not support switching, the app should simply verify the user is on the correct chain and proceed with the transaction rather than failing.